### PR TITLE
A cor vermelho não está especificada no banco

### DIFF
--- a/Consultas Aninhadas/EXERCICIOS.txt
+++ b/Consultas Aninhadas/EXERCICIOS.txt
@@ -1,6 +1,6 @@
 Faça duas consultas, utilizando in e exists para:
 - Verificar os marinheiros que não reservaram o barco 103 
-- Verificar os marinheiros que reservaram o barco de cor vermelho
+- Verificar os marinheiros que reservaram o barco de cor vermelho ("verm")
 
 extra:
 - Simule uma consulta (teste de mesa) com exists fazendo o produto cartesiano. 


### PR DESCRIPTION
O exercicio pede uma seleção influenciada pela cor do barco, entretanto, no banco de dados, a cor está escrita como "verm", assim, é nescessário a especificação de como está nomeado o campo.
